### PR TITLE
Separating Suspend/Resume types

### DIFF
--- a/InsulinKit/DoseEntry.swift
+++ b/InsulinKit/DoseEntry.swift
@@ -20,12 +20,20 @@ public struct DoseEntry: TimelineValue {
     public let description: String?
     let managedObjectID: NSManagedObjectID? = nil
 
-    public init(type: PumpEventType, startDate: NSDate, endDate: NSDate, value: Double, unit: DoseUnit, description: String? = nil) {
+    public init(type: PumpEventType, startDate: NSDate, endDate: NSDate? = nil, value: Double, unit: DoseUnit, description: String? = nil) {
         self.type = type
         self.startDate = startDate
-        self.endDate = endDate
+        self.endDate = endDate ?? startDate
         self.value = value
         self.unit = unit
         self.description = description
+    }
+
+    public init(suspendDate: NSDate) {
+        self.init(type: .suspend, startDate: suspendDate, value: 0, unit: .unitsPerHour)
+    }
+
+    public init(resumeDate: NSDate) {
+        self.init(type: .resume, startDate: resumeDate, value: 0, unit: .unitsPerHour)
     }
 }

--- a/InsulinKit/DoseUnit.swift
+++ b/InsulinKit/DoseUnit.swift
@@ -10,6 +10,6 @@ import Foundation
 
 
 public enum DoseUnit: String {
-    case UnitsPerHour = "U/hour"
-    case Units        = "U"
+    case unitsPerHour = "U/hour"
+    case units        = "U"
 }

--- a/InsulinKit/PumpEventType.swift
+++ b/InsulinKit/PumpEventType.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 
+/// A subset of pump event types, with raw values matching decocare's strings
 public enum PumpEventType: String {
-    case Bolus     = "Bolus"
-    case Suspend   = "PumpSuspend"
-    case TempBasal = "TempBasal"
+    case bolus     = "Bolus"
+    case resume    = "PumpResume"
+    case suspend   = "PumpSuspend"
+    case tempBasal = "TempBasal"
 }

--- a/InsulinKitTests/Fixtures/normalize_edge_case_doses_input.json
+++ b/InsulinKitTests/Fixtures/normalize_edge_case_doses_input.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "TempBasal",
-        "start_at": "2015-07-12T23:59:00",
+        "start_at": "2015-07-12T23:59:59",
         "end_at": "2015-07-13T07:54:00",
         "amount": 2.0,
         "unit": "U/hour"

--- a/InsulinKitTests/Fixtures/normalize_edge_case_doses_output.json
+++ b/InsulinKitTests/Fixtures/normalize_edge_case_doses_output.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "TempBasal",
-        "start_at": "2015-07-12T23:59:00",
+        "start_at": "2015-07-12T23:59:59",
         "end_at": "2015-07-13T00:00:00",
         "amount": 1.1,
         "unit": "U/hour"

--- a/InsulinKitTests/Fixtures/reconcile_history_input.json
+++ b/InsulinKitTests/Fixtures/reconcile_history_input.json
@@ -314,7 +314,7 @@
     {
         "amount": 0,
         "description": "Pump Suspend",
-        "end_at": "2016-02-15T20:25:01",
+        "end_at": "2016-02-15T20:19:21",
         "start_at": "2016-02-15T20:19:21",
         "type": "PumpSuspend",
         "unit": "U/hour"
@@ -326,6 +326,14 @@
         "start_at": "2016-02-15T20:18:54",
         "type": "Bolus",
         "unit": "U"
+    },
+    {
+        "amount": 0,
+        "description": "Pump Resume",
+        "end_at": "2016-02-15T20:25:01",
+        "start_at": "2016-02-15T20:25:01",
+        "type": "PumpResume",
+        "unit": "U/hour"
     },
     {
         "amount": 2.875,

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -214,8 +214,6 @@ class InsulinMathTests: XCTestCase {
 
         let doses = InsulinMath.reconcileDoses(input).sort { $0.startDate < $1.startDate }
 
-        print(output)
-
         XCTAssertEqual(output.count, doses.count)
 
         for (expected, calculated) in zip(output, doses) {

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -214,6 +214,8 @@ class InsulinMathTests: XCTestCase {
 
         let doses = InsulinMath.reconcileDoses(input).sort { $0.startDate < $1.startDate }
 
+        print(output)
+
         XCTAssertEqual(output.count, doses.count)
 
         for (expected, calculated) in zip(output, doses) {
@@ -313,6 +315,6 @@ class InsulinMathTests: XCTestCase {
         let input = loadDoseFixture("normalize_edge_case_doses_input")
         let output = InsulinMath.totalDeliveryForDoses(input)
 
-        XCTAssertEqualWithAccuracy(18.83, output, accuracy: pow(10, -2))
+        XCTAssertEqualWithAccuracy(18.8, output, accuracy: pow(10, -2))
     }
 }

--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -78,7 +78,7 @@ public class GlucoseRangeSchedule: DailyQuantitySchedule<DoubleRange> {
         temporaryOverride = nil
     }
 
-    public init?(unit: HKUnit, dailyItems: [RepeatingScheduleValue<DoubleRange>], workoutRange: DoubleRange?, timeZone: NSTimeZone? = nil) {
+    public init?(unit: HKUnit, dailyItems: [RepeatingScheduleValue<DoubleRange>], workoutRange: DoubleRange? = nil, timeZone: NSTimeZone? = nil) {
         self.workoutRange = workoutRange
 
         super.init(unit: unit, dailyItems: dailyItems, timeZone: timeZone)


### PR DESCRIPTION
This makes the add interface a lot easier to use. `reconcileDoses` is updated to manage both types.