### PR TITLE
Increase the potential maximum reservoir drop rate

### DIFF
--- a/InsulinKit/InsulinMath.swift
+++ b/InsulinKit/InsulinMath.swift
@@ -133,12 +133,15 @@ struct InsulinMath {
     }
 
     /**
-     It takes a MM pump about 40s to deliver 1 Unit while bolusing
+     It takes a MM x22 pump about 40s to deliver 1 Unit while bolusing
      See: http://www.healthline.com/diabetesmine/ask-dmine-speed-insulin-pumps#3
+     
+     The x23 and newer pumps can deliver at 2x, 3x, and 4x that speed, targeting
+     a maximum 5-minute delivery for all boluses (8U - 25U)
      
      A basal rate of 30 U/hour (near-max) would deliver an additional 0.5 U/min.
      */
-    private static let MaximumReservoirDropPerMinute = 2.0
+    private static let MaximumReservoirDropPerMinute = 6.5
 
     /**
      Converts a continuous sequence of reservoir values to a sequence of doses
@@ -211,6 +214,12 @@ struct InsulinMath {
 
             // We can't trust 0. What else was delivered?
             guard value.unitVolume > 0 else {
+                return false
+            }
+
+            // Rises in reservoir volume indicate a rewind + prime, and primes
+            // can be easily confused with boluses.
+            guard value.unitVolume <= lastValue.unitVolume else {
                 return false
             }
 

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -114,7 +114,10 @@ class InsulinMathTests: XCTestCase {
         XCTAssertFalse(InsulinMath.isContinuous(input, from: dateFormatter.dateFromString("2016-01-30T15:00:00")!, to: dateFormatter.dateFromString("2016-01-30T20:40:00")!))
 
         // (the boundary condition is GTE)
-        XCTAssertTrue(InsulinMath.isContinuous(input, from: dateFormatter.dateFromString("2016-01-30T15:40:49")!, to: dateFormatter.dateFromString("2016-01-30T20:40:00")!))
+        XCTAssertTrue(InsulinMath.isContinuous(input, from: dateFormatter.dateFromString("2016-01-30T16:00:42")!, to: dateFormatter.dateFromString("2016-01-30T20:40:00")!))
+
+        // Rises in reservoir volume taint the entire range
+        XCTAssertFalse(InsulinMath.isContinuous(input, from: dateFormatter.dateFromString("2016-01-30T15:55:00")!, to: dateFormatter.dateFromString("2016-01-30T20:40:00")!))
 
         // Any values of 0 taint the entire range
         input.append(NewReservoirValue(startDate: dateFormatter.dateFromString("2016-01-30T20:37:00")!, unitVolume: 0))


### PR DESCRIPTION
Fast boluses on x23 pumps were occasionally missed.

Now that history-derived insulin data is available, we now assume reservoir data after a rewind/prime is always unreliable.

cc @ps2

Fixes #66